### PR TITLE
StarMonitor updates

### DIFF
--- a/find_star/__main__.py
+++ b/find_star/__main__.py
@@ -1,45 +1,48 @@
-import sys
-import json
-import logging
 
+import logging
 from ._constants import VERBOSE
 
 if VERBOSE:
-    logging.basicConfig(level=logging.DEBUG)
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(asctime)s | %(levelname)s | %(filename)s.%(funcName)s: %(message)s",
+    )
+
+# pylint: disable=C0413
+import sys
+import json
+
+from os import getenv
 
 from .find_star import StarMonitor
 from .discord import DiscordNotifier
 from .cli_arguments import cli_arguments
 
-from ._constants.discord import DISCORD_WEBHOOK_ENDPOINT
 
-if not DISCORD_WEBHOOK_ENDPOINT:
-    logging.error("Unset manditory variable: DISCORD_WEBHOOK_ENDPOINT")
-    sys.exit(1)
+def main():
+    discord_endpoint = getenv("DISCORD_WEBHOOK_ENDPOINT")
+    message_handler = DiscordNotifier(discord_endpoint)
+    cli_args = cli_arguments()
+    worlds = cli_args.pop("worlds")
+    monitor = StarMonitor(
+        *worlds,
+        max_age=cli_args["max_age"],
+        min_tier=cli_args["min_tier"],
+        mining_lvl=cli_args["mining_lvl"]
+    )
+
+    logging.debug("Running with settings: %r", cli_args)
+    if cli_args["daemon"]:
+        monitor.background_notify(message_handler)
+
+    star = monitor.get_star()
+    if not star:
+        logging.info("No Star in requested world")
+        sys.exit(1)
+
+    star["time"] = star["time"].isoformat()
+    json.dump(star, sys.stdout)
+    sys.exit(0)
 
 
-message_handler = DiscordNotifier(DISCORD_WEBHOOK_ENDPOINT)
-cli_args = cli_arguments()
-worlds = cli_args.pop("worlds")
-monitor = StarMonitor(
-    *worlds,
-    max_age=cli_args["max_age"],
-    min_tier=cli_args["min_tier"],
-    mining_lvl=cli_args["mining_lvl"]
-)
-
-logging.debug("Running with settings: %r", cli_args)
-if cli_args["daemon"]:
-    monitor.background_notify(message_handler)
-
-if VERBOSE:
-    logging.basicConfig(level=logging.DEBUG)
-
-star = monitor.get_star()
-if not star:
-    logging.info("No Star in requested world")
-    sys.exit(1)
-
-star["time"] = star["time"].isoformat()
-json.dump(star, sys.stdout)
-sys.exit(0)
+main()

--- a/find_star/_constants/__init__.py
+++ b/find_star/_constants/__init__.py
@@ -1,7 +1,6 @@
-from . import discord, osrsportal, star_parameters, probe_delays
+from . import discord, osrsportal, star_parameters, external_probes
 from .debug import DEBUG, VERBOSE
 
-EXTERNAL_CONNECTION_TIMEOUT = 30
 
 __all__ = (
     "DEBUG",
@@ -9,5 +8,5 @@ __all__ = (
     "discord",
     "osrsportal",
     "star_parameters",
-    "probe_delays",
+    "external_probes",
 )

--- a/find_star/_constants/discord.py
+++ b/find_star/_constants/discord.py
@@ -2,19 +2,51 @@ from os import getenv
 
 __all__ = (
     "DISCORD_WEBHOOK_ENDPOINT",
-    "STARHUNTER_ROLE_ID",
-    "DISCORD_MESSAGE_SPEC",
+    "DISCORD_PAYLOAD",
+    "EXTRA_FORMAT_ARGS",
 )
+
+STARHUNTER_ROLE_ID = getenv("STARHUNTER_ROLE_ID", "000000")
 
 DISCORD_WEBHOOK_ENDPOINT = getenv(
     "DISCORD_WEBHOOK_ENDPOINT",
 )
 
-STARHUNTER_ROLE_ID = getenv("STARHUNTER_ROLE_ID", "StarHunters")
+EXTRA_FORMAT_ARGS = {
+    "role_mention": f"<@&{STARHUNTER_ROLE_ID}>",
+    "dynamic_ts": "<t:{time:%s}:R>",
+}
 
 DISCORD_MESSAGE_SPEC = """
-**T{tier:d} Star** at **{loc:s}** <@&%(role_id)s> 
-> ~<t:{time:d}:R> by {scout:s} on [osrsportal](https://osrsportal.com/shooting-stars-tracker)
-""".strip() % {
-    "role_id": STARHUNTER_ROLE_ID
+**T{tier:d} Star** at **{loc:s}** {role_mention}
+> {dynamic_ts:s} by {scout:s} on [osrsportal](https://osrsportal.com/shooting-stars-tracker)
+""".strip()
+
+DISCORD_EMBEDS = (
+    [
+        {
+            "title": "#get-roles for W444 Star Notifications",
+            "url": "https://discord.com/channels/1172035731837960242/1185740071488471040",
+            "footer": {
+                "text": "Follow the #get-roles link and react to Star Watcher to receive Discord pings",
+            },
+        },
+    ],
+)
+
+DISCORD_USER_NAME = "Star Watcher"
+
+DISCORD_PAYLOAD = {
+    # https://birdie0.github.io/discord-webhooks-guide/discord_webhook.html
+    "username": DISCORD_USER_NAME,
+    "content": DISCORD_MESSAGE_SPEC,  # Will be formatted when posting to Discord
+    "embeds": [
+        {
+            "title": "#get-roles for W444 Star Notifications",
+            "url": "https://discord.com/channels/1172035731837960242/1185740071488471040",
+            "footer": {
+                "text": "Follow the #get-roles link and react to Star Watcher to receive Discord pings",
+            },
+        },
+    ],
 }

--- a/find_star/_constants/external_probes.py
+++ b/find_star/_constants/external_probes.py
@@ -1,6 +1,6 @@
 __all__ = (
     "SEARCH_DELAY",
-    "PER_TIER_DELAY",
+    "EXTERNAL_CONNECTION_TIMEOUT",
 )
 
 # WARNING-start
@@ -10,6 +10,4 @@ SEARCH_DELAY = 45
 # unaffiliated endpoint, which they may not appreciate!
 # WARNING-end
 
-_minute = 60
-
-PER_TIER_DELAY = _minute * 7  # 7 minutes wait per tier on found star
+EXTERNAL_CONNECTION_TIMEOUT = 30

--- a/find_star/_constants/star_parameters.py
+++ b/find_star/_constants/star_parameters.py
@@ -4,6 +4,7 @@ __all__ = (
     "MINING_LEVEL",
 )
 
+# Here be the Defaults (if no cli argument was given)
 MAXIMAL_AGE = 5
 MINIMAL_TIER = 3
 MINING_LEVEL = 99

--- a/find_star/discord/notifier.py
+++ b/find_star/discord/notifier.py
@@ -103,7 +103,7 @@ class DiscordNotifier:
             headers=self.headers,
             timeout=EXTERNAL_CONNECTION_TIMEOUT,
         )
-        if ret.status_code in [200, 201, 204, 404]:
+        if ret.status_code in [200, 201, 204]:
             self.__last_star = __star_info
             return
         logger.error(

--- a/find_star/discord/notifier.py
+++ b/find_star/discord/notifier.py
@@ -21,18 +21,33 @@ import json
 import logging as logger
 
 from copy import copy
+from datetime import timedelta
 from typing import TYPE_CHECKING
 
 import requests
 
-from .._constants import EXTERNAL_CONNECTION_TIMEOUT, DEBUG, VERBOSE
-from .._constants.discord import DISCORD_MESSAGE_SPEC
+from .._constants import DEBUG
+from .._constants.discord import DISCORD_PAYLOAD, EXTRA_FORMAT_ARGS
+from .._constants.external_probes import EXTERNAL_CONNECTION_TIMEOUT
+
 
 if TYPE_CHECKING:
-    from typing import Dict, Any
+    from typing import Optional, Dict, Any
     from ..osrsportal.data_structure import Star
 
 __all__ = ("DiscordNotifier",)
+
+
+def same_star(new_star: Star, old_star: Star = None):
+    if not old_star:
+        return False
+    if old_star["world"] != new_star["world"]:
+        return False
+    if old_star["loc"] == new_star["loc"]:
+        return (old_star["time"] + timedelta(minutes=90)).timestamp() > new_star[
+            "time"
+        ].timestamp()
+    return False
 
 
 class DiscordNotifier:
@@ -44,21 +59,9 @@ class DiscordNotifier:
     """
 
     headers: "Dict[str, str]" = {"Content-Type": "application/json"}
-    payload: "Dict[str, Any]" = {
-        "username": "Star Watcher",
-        "content": DISCORD_MESSAGE_SPEC,  # Will be formatted when posting to Discord
-        "embeds": [
-            {
-                "title": "#get-roles for W444 Star Notifications",
-                "url": "https://discord.com/channels/1172035731837960242/1185740071488471040",
-                "footer": {
-                    "text": "Follow the #get-roles link and react to Star Watcher to receive Discord pings",
-                },
-            },
-        ],
-    }
-
+    payload: "Dict[str, Any]" = DISCORD_PAYLOAD
     __endpoint: str
+    __last_star: "Optional[Star]" = None
 
     def __init__(
         self,
@@ -71,18 +74,26 @@ class DiscordNotifier:
         __endpoint: str
             Discord webhook 'uri'
         """
+        if not __endpoint:
+            raise ValueError("Missing Discord webhook endpoint")
         self.__endpoint = __endpoint
 
-    def __call__(self, __star_info: "Star") -> "requests.Response":
+    def __call__(self, __star_info: "Star") -> "Optional[requests.Response]":
         """Send notification to Discord"""
-        star = __star_info
-        _scout_time = star["time"]
-        star["time"] = round(_scout_time.timestamp())
+        if same_star(__star_info, self.__last_star):
+            if DEBUG:
+                logger.debug("Already posted star to Discord, skipping")
+            return
+        format_args = {
+            k: v.format(**__star_info) for k, v in EXTRA_FORMAT_ARGS.items()
+        }
+        format_args.update(__star_info)
         payload = copy(self.payload)
         payload["content"] = (
-            # Format tempate message with star info
-            payload["content"].format(**star)
+            # Format template message with star info
+            payload["content"].format(**format_args)
         )
+
         if DEBUG:
             logger.debug(
                 "Sending the following message to Discord:\n%r", payload)
@@ -92,11 +103,14 @@ class DiscordNotifier:
             headers=self.headers,
             timeout=EXTERNAL_CONNECTION_TIMEOUT,
         )
-        if ret.status_code not in [200, 201, 204]:
-            logger.error(
-                "Failed to post message to discord (status=%d)", ret.status_code
+        if ret.status_code in [200, 201, 204, 404]:
+            self.__last_star = __star_info
+            return
+        logger.error(
+            "Failed to post message to discord (status=%d)", ret.status_code)
+        if DEBUG:
+            logger.debug(
+                "Send to discord: \n\t%r\nAnd received:\n\t%r",
+                ret.request.body,
+                ret.text,
             )
-            if VERBOSE:
-                logger.debug("Send to discord: \n\t%r\nAnd received:\n\t%r",
-                             ret.request.body, ret.text)
-        return ret

--- a/find_star/find_star.py
+++ b/find_star/find_star.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING
 from .osrsportal import get_osrsportal_stars
 
 from ._constants import VERBOSE
-from ._constants.probe_delays import PER_TIER_DELAY, SEARCH_DELAY
+from ._constants.external_probes import SEARCH_DELAY
 from ._constants.star_parameters import (
     MAXIMAL_AGE,
     MINIMAL_TIER,
@@ -112,10 +112,6 @@ class StarMonitor:
             eligible_star = star
         return eligible_star or None
 
-    @staticmethod
-    def calculate_star_duration(tier: int) -> int:
-        return (tier * PER_TIER_DELAY)
-
     def get_star(self) -> "Optional[Star]":
         return self.__find_suitable_star(self.__star_getter())
 
@@ -138,10 +134,6 @@ class StarMonitor:
                 if star:
                     logger.info("Found star: %r", star)
                     __notification_hook(star)
-                    tier = star["tier"]
-                    idle_time = self.calculate_star_duration(tier)
-                    sleep(idle_time)
-                    continue
                 sleep(SEARCH_DELAY)  # 60 seconds
             except KeyboardInterrupt as _e:
                 logger.debug("Caught exit signal %s, exiting...", _e)

--- a/find_star/osrsportal/__init__.py
+++ b/find_star/osrsportal/__init__.py
@@ -1,3 +1,4 @@
+
 from .data_structure import Star
 from .get_stars import get_osrsportal_stars
 

--- a/find_star/osrsportal/auth_header.py
+++ b/find_star/osrsportal/auth_header.py
@@ -7,8 +7,8 @@ from math import floor
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from .._constants import EXTERNAL_CONNECTION_TIMEOUT
 from .._constants.osrsportal import BEARER_FORMAT_SPEC
+from .._constants.external_probes import EXTERNAL_CONNECTION_TIMEOUT
 
 if TYPE_CHECKING:
     from typing import Dict, Any

--- a/find_star/osrsportal/get_stars.py
+++ b/find_star/osrsportal/get_stars.py
@@ -10,8 +10,9 @@ import requests
 from .data_structure import Star
 from .auth_header import osrs_portal_auth_header
 
-from .._constants import EXTERNAL_CONNECTION_TIMEOUT, DEBUG
+from .._constants import DEBUG
 from .._constants.osrsportal import ACTIVE_STARS_ENDPOINT
+from .._constants.external_probes import EXTERNAL_CONNECTION_TIMEOUT
 
 if TYPE_CHECKING:
     from typing import Iterable


### PR DESCRIPTION
- Removed 'sleep(tier * 7)' logic,
- Moved everything to do with 'discord message' to `find_star/_constants/discord.py`
- Did some cleanup that still had to happened
- Added a log format with timestamps for when 'VERBOSE' or 'DEBUG' mode is activated.